### PR TITLE
Bugfix: reference to Module is ambiguous

### DIFF
--- a/src/main/java/org/yangcentral/yangkit/plugin/stat/YangStatistics.java
+++ b/src/main/java/org/yangcentral/yangkit/plugin/stat/YangStatistics.java
@@ -12,6 +12,7 @@ import org.yangcentral.yangkit.compiler.Settings;
 import org.yangcentral.yangkit.compiler.YangCompilerException;
 import org.yangcentral.yangkit.model.api.schema.YangSchemaContext;
 import org.yangcentral.yangkit.model.api.stmt.*;
+import org.yangcentral.yangkit.model.api.stmt.Module;
 import org.yangcentral.yangkit.plugin.YangCompilerPlugin;
 import org.yangcentral.yangkit.plugin.YangCompilerPluginParameter;
 


### PR DESCRIPTION
Fixes:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project yang-compiler: Compilation failure
[ERROR] /Users/taatomae/repos/yang-compiler/src/main/java/org/yangcentral/yangkit/plugin/stat/YangStatistics.java:[79,13] reference to Module is ambiguous
[ERROR]   both interface org.yangcentral.yangkit.model.api.stmt.Module in org.yangcentral.yangkit.model.api.stmt and class java.lang.Module in java.lang match
```

The error is because of the new class [java.lang.Module](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Module.html) introduced in Java-9.